### PR TITLE
improve Uniswap V3 support

### DIFF
--- a/docs/trading-entities.md
+++ b/docs/trading-entities.md
@@ -22,11 +22,12 @@ See [Typesense field types](https://typesense.org/docs/0.22.2/api/collections.ht
 | `smart_contract_addresses` | `string[]` | &#x2713; | &#x2713; | &#x2717; | array of all indexable addresses for the type |
 | `token_tickers` | `string[]` | &#x2717; | &#x2713; | &#x2717; | array of all indexable token tickers for the type |
 | `token_names` | `string[]` | &#x2717; | &#x2713; | &#x2717; | array of all indexable token names for the type |
+| `quality_factors` | `string[]` | &#x2717; | &#x2717; | &#x2717; | array of factors used to identify "low quality" entities<br>current possible values: `liquidity` |
 | `volume_24h` | `float` | &#x2717; | &#x2717; | &#x2717; | in USD; advanced search filtering / ranking |
 | `liquidity` | `float` | &#x2717; | &#x2717; | &#x2717; | in USD; advanced search filtering / ranking |
 | `price_change_24h` | `float` | &#x2717; | &#x2717; | &#x2717; | percent (expresed as decimal); secondary sort criterion for tokens & pairs |
 | `price_usd_latest` | `float` | &#x2717; | &#x2717; | &#x2717; | in USD; not valuable for filtering / ranking - used for display only |
-| `icon_url` | `string` | &#x2717; | &#x2717; | &#x2717; | future use |
+| `pool_swap_fee` | `float` | &#x2717; | &#x2717; | &#x2717; | percent (expressed as decimal); only applies to Uniswap V3 (or similar) pairs<br>current possible values: `0.0005` (`0.05%`), `0.003` (`0.3%`), `0.01` (1%) |
 | `url_path` | `string` | &#x2717; | &#x2717; | &#x2717; | path of entity on tradingstrategy.ai (not including URL base) |
 
 ## File Format
@@ -45,13 +46,13 @@ Collection import files should be in [JSON Lines](https://jsonlines.org) format 
   "name": "QuickSwap",
   "description": "Quickswap exchange on Polygon",
   "blockchain": "Polygon",
+  "exchange": "QuickSwap",
   "smart_contract_addresses": ["0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32"],
   "token_tickers": [],
   "token_names": [],
   "price_change_24h": null,
   "volume_24h": null,
   "liquidity": null,
-  "icon_url": "https://some.url/icon_path.png",
   "url_path": "/polygon/quickswap"
 }
 ```
@@ -66,13 +67,13 @@ Collection import files should be in [JSON Lines](https://jsonlines.org) format 
   "name": "Aave (AAVE)",
   "description": "Aave (AAVE) token on Ethereum",
   "blockchain": "Ethereum",
+  "exchange": "",
   "smart_contract_addresses": ["0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9"],
   "token_tickers": ["AAVE"],
   "token_names": ["Aave"],
   "price_change_24h": 0.0123,
   "volume_24h": 123456.78,
   "liquidity": 234567.89,
-  "icon_url": "https://some.url/icon_path.png",
   "url_path": "/ethereum/aave"
 }
 ```
@@ -87,13 +88,15 @@ Collection import files should be in [JSON Lines](https://jsonlines.org) format 
   "name": "AAVE-ETH",
   "description": "AAVE-ETH trading pair on SushiSwap on Ethereum",
   "blockchain": "Ethereum",
+  "exchange": "SushiSwap",
   "smart_contract_addresses": ["0xd75ea151a61d06868e31f8988d28dfe5e9df57b4", "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"],
   "token_tickers": ["AAVE", "ETH"],
   "token_names": ["Aave", "Ether"],
+  "quality_factors": ["liquidity"],
   "price_change_24h": -0.0345,
   "volume_24h": 123456.78,
   "liquidity": 234567.89,
-  "icon_url": "https://some.url/icon_path.png",
+  "pool_swap_fee": null,
   "url_path": "/ethereum/sushiswap/aave-eth"
 }
 ```

--- a/docs/trading-entities.md
+++ b/docs/trading-entities.md
@@ -11,24 +11,24 @@ for filtering and sorting.
 See [Typesense field types](https://typesense.org/docs/0.22.2/api/collections.html#field-types)
 
 | Field | Type | Required | Index | Facet | Details |
-| --- | --- | :---: | :---: | :---: | --- |
-| `id` | `string` | &#x2713; | &#x2717; | &#x2717; | `exchange_1` \| `token_2345` \| `pair_45678` |
-| `type` | `string` | &#x2713; | &#x2713; | &#x2713; | `exchange` \| `token` \| `pair`<br>for faceting and possibly grouping results |
-| `type_rank` | `int32` | &#x2713; | &#x2713; | &#x2717; | `exchange=1` \| `token=2` \| `pair=3`<br>for ranking; may not need this (depends how we rank and group results)|
-| `name` | `string` | &#x2713; | &#x2713; | &#x2717; | `exchange:` "QuickSwap" \| `token:` "Aave (AAVE)" \| `pair:` "AAVE-ETH" |
-| `description` | `string` | &#x2713; | &#x2713; | &#x2717; | `exchange:` "QuickSwap on Polygon" \| `token:` "Aave (AAVE) token on Ethereum" \| `pair:` "AAVE-ETH trading pair on SushiSwap on Ethereum" |
-| `blockchain` | `string` | &#x2713; | &#x2713; | &#x2713; | e.g., "polygon", "ethereum" |
-| `exchange` | `string` | &#x2713; | &#x2713; | &#x2713; | e.g., "Uniswap v2", "Sushiswap"<br>same as `name` for exchanges; set to `exchange.name` for pairs; set to `""` (empty string) for tokens |
-| `smart_contract_addresses` | `string[]` | &#x2713; | &#x2713; | &#x2717; | array of all indexable addresses for the type |
-| `token_tickers` | `string[]` | &#x2717; | &#x2713; | &#x2717; | array of all indexable token tickers for the type |
-| `token_names` | `string[]` | &#x2717; | &#x2713; | &#x2717; | array of all indexable token names for the type |
-| `quality_factors` | `string[]` | &#x2717; | &#x2717; | &#x2717; | array of factors used to identify "low quality" entities<br>current possible values: `liquidity` |
-| `volume_24h` | `float` | &#x2717; | &#x2713; | &#x2717; | in USD; advanced search filtering / ranking |
-| `liquidity` | `float` | &#x2717; | &#x2713; | &#x2717; | in USD; advanced search filtering / ranking |
-| `price_change_24h` | `float` | &#x2717; | &#x2713; | &#x2717; | percent (expresed as decimal); secondary sort criterion for tokens & pairs |
-| `price_usd_latest` | `float` | &#x2717; | &#x2713; | &#x2717; | in USD; not valuable for filtering / ranking - used for display only |
-| `pool_swap_fee` | `float` | &#x2717; | &#x2713; | &#x2717; | percent (expressed as decimal); only applies to Uniswap V3 (or similar) pairs<br>current possible values: `0.0005` (`0.05%`), `0.003` (`0.3%`), `0.01` (1%) |
-| `url_path` | `string` | &#x2717; | &#x2717; | &#x2717; | path of entity on tradingstrategy.ai (not including URL base) |
+| ---   | ---  | :---:    | :---: | :---: | ---     |
+| `id`                       | `string`   | ✓ | ✗ | ✗ | `exchange_1` \| `token_2345` \| `pair_45678` |
+| `type`                     | `string`   | ✓ | ✓ | ✓ | `exchange` \| `token` \| `pair`<br>for faceting and possibly grouping results |
+| `type_rank`                | `int32`    | ✓ | ✓ | ✗ | `exchange=1` \| `pair=3` \| `token=2`<br>for ranking; may not need this (depends how we rank and group results)|
+| `name`                     | `string`   | ✓ | ✓ | ✗ | `exchange:` "QuickSwap" \| `token:` "Aave (AAVE)" \| `pair:` "AAVE-ETH" |
+| `description`              | `string`   | ✓ | ✓ | ✗ | `exchange:` "QuickSwap on Polygon" \| `token:` "Aave (AAVE) token on Ethereum" \| `pair:` "AAVE-ETH trading pair on SushiSwap on Ethereum" |
+| `blockchain`               | `string`   | ✓ | ✓ | ✓ | e.g., "polygon", "ethereum" |
+| `exchange`                 | `string`   | ✓ | ✓ | ✓ | e.g., "Uniswap v2", "Sushiswap"<br>same as `name` for exchanges; set to `exchange.name` for pairs; set to `""` (empty string) for tokens |
+| `smart_contract_addresses` | `string[]` | ✓ | ✓ | ✗ | array of all indexable addresses for the type |
+| `token_tickers`            | `string[]` | ✗ | ✓ | ✗ | array of all indexable token tickers for the type |
+| `token_names`              | `string[]` | ✗ | ✓ | ✗ | array of all indexable token names for the type |
+| `quality_factors`          | `string[]` | ✗ | ✗ | ✗ | array of factors used to identify "low quality" entities<br>current possible values: `liquidity` |
+| `volume_24h`               | `float`    | ✗ | ✓ | ✗ | in USD; advanced search filtering / ranking |
+| `liquidity`                | `float`    | ✗ | ✓ | ✗ | in USD; advanced search filtering / ranking |
+| `price_change_24h`         | `float`    | ✗ | ✓ | ✗ | percent (expresed as decimal); secondary sort criterion for tokens & pairs |
+| `price_usd_latest`         | `float`    | ✗ | ✓ | ✗ | in USD; not valuable for filtering / ranking - used for display only |
+| `pool_swap_fee`            | `float`    | ✗ | ✓ | ✗ | percent (expressed as decimal); only applies to Uniswap V3 (or similar) pairs<br>current possible values: `0.0005` (`0.05%`), `0.003` (`0.3%`), `0.01` (1%) |
+| `url_path`                 | `string`   | ✗ | ✗ | ✗ | path of entity on tradingstrategy.ai (not including URL base) |
 
 ## File Format
 
@@ -50,7 +50,6 @@ Collection import files should be in [JSON Lines](https://jsonlines.org) format 
   "smart_contract_addresses": ["0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32"],
   "token_tickers": [],
   "token_names": [],
-  "price_change_24h": null,
   "volume_24h": null,
   "liquidity": null,
   "url_path": "/polygon/quickswap"
@@ -63,7 +62,7 @@ Collection import files should be in [JSON Lines](https://jsonlines.org) format 
 {
   "id": "token_23456",
   "type": "token",
-  "type_rank": 2,
+  "type_rank": 4,
   "name": "Aave (AAVE)",
   "description": "Aave (AAVE) token on Ethereum",
   "blockchain": "Ethereum",
@@ -71,7 +70,6 @@ Collection import files should be in [JSON Lines](https://jsonlines.org) format 
   "smart_contract_addresses": ["0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9"],
   "token_tickers": ["AAVE"],
   "token_names": ["Aave"],
-  "price_change_24h": 0.0123,
   "volume_24h": 123456.78,
   "liquidity": 234567.89,
   "url_path": "/ethereum/aave"
@@ -93,9 +91,10 @@ Collection import files should be in [JSON Lines](https://jsonlines.org) format 
   "token_tickers": ["AAVE", "ETH"],
   "token_names": ["Aave", "Ether"],
   "quality_factors": ["liquidity"],
-  "price_change_24h": -0.0345,
   "volume_24h": 123456.78,
   "liquidity": 234567.89,
+  "price_change_24h": -0.0345,
+  "price_usd_latest": 93.5,
   "pool_swap_fee": null,
   "url_path": "/ethereum/sushiswap/aave-eth"
 }

--- a/docs/trading-entities.md
+++ b/docs/trading-entities.md
@@ -13,21 +13,21 @@ See [Typesense field types](https://typesense.org/docs/0.22.2/api/collections.ht
 | Field | Type | Required | Index | Facet | Details |
 | --- | --- | :---: | :---: | :---: | --- |
 | `id` | `string` | &#x2713; | &#x2717; | &#x2717; | `exchange_1` \| `token_2345` \| `pair_45678` |
-| `type` | `string` | &#x2713; | &#x2717; | &#x2713; | `exchange` \| `token` \| `pair`<br>for faceting and possibly grouping results |
-| `type_rank` | `int32` | &#x2713; | &#x2717; | &#x2717; | `exchange=1` \| `token=2` \| `pair=3`<br>for ranking; may not need this (depends how we rank and group results)|
+| `type` | `string` | &#x2713; | &#x2713; | &#x2713; | `exchange` \| `token` \| `pair`<br>for faceting and possibly grouping results |
+| `type_rank` | `int32` | &#x2713; | &#x2713; | &#x2717; | `exchange=1` \| `token=2` \| `pair=3`<br>for ranking; may not need this (depends how we rank and group results)|
 | `name` | `string` | &#x2713; | &#x2713; | &#x2717; | `exchange:` "QuickSwap" \| `token:` "Aave (AAVE)" \| `pair:` "AAVE-ETH" |
 | `description` | `string` | &#x2713; | &#x2713; | &#x2717; | `exchange:` "QuickSwap on Polygon" \| `token:` "Aave (AAVE) token on Ethereum" \| `pair:` "AAVE-ETH trading pair on SushiSwap on Ethereum" |
-| `blockchain` | `string` | &#x2713; | &#x2717; | &#x2713; | e.g., "polygon", "ethereum" |
-| `exchange` | `string` | &#x2713; | &#x2717; | &#x2713; | e.g., "Uniswap v2", "Sushiswap"<br>same as `name` for exchanges; set to `exchange.name` for pairs; set to `""` (empty string) for tokens |
+| `blockchain` | `string` | &#x2713; | &#x2713; | &#x2713; | e.g., "polygon", "ethereum" |
+| `exchange` | `string` | &#x2713; | &#x2713; | &#x2713; | e.g., "Uniswap v2", "Sushiswap"<br>same as `name` for exchanges; set to `exchange.name` for pairs; set to `""` (empty string) for tokens |
 | `smart_contract_addresses` | `string[]` | &#x2713; | &#x2713; | &#x2717; | array of all indexable addresses for the type |
 | `token_tickers` | `string[]` | &#x2717; | &#x2713; | &#x2717; | array of all indexable token tickers for the type |
 | `token_names` | `string[]` | &#x2717; | &#x2713; | &#x2717; | array of all indexable token names for the type |
 | `quality_factors` | `string[]` | &#x2717; | &#x2717; | &#x2717; | array of factors used to identify "low quality" entities<br>current possible values: `liquidity` |
-| `volume_24h` | `float` | &#x2717; | &#x2717; | &#x2717; | in USD; advanced search filtering / ranking |
-| `liquidity` | `float` | &#x2717; | &#x2717; | &#x2717; | in USD; advanced search filtering / ranking |
-| `price_change_24h` | `float` | &#x2717; | &#x2717; | &#x2717; | percent (expresed as decimal); secondary sort criterion for tokens & pairs |
-| `price_usd_latest` | `float` | &#x2717; | &#x2717; | &#x2717; | in USD; not valuable for filtering / ranking - used for display only |
-| `pool_swap_fee` | `float` | &#x2717; | &#x2717; | &#x2717; | percent (expressed as decimal); only applies to Uniswap V3 (or similar) pairs<br>current possible values: `0.0005` (`0.05%`), `0.003` (`0.3%`), `0.01` (1%) |
+| `volume_24h` | `float` | &#x2717; | &#x2713; | &#x2717; | in USD; advanced search filtering / ranking |
+| `liquidity` | `float` | &#x2717; | &#x2713; | &#x2717; | in USD; advanced search filtering / ranking |
+| `price_change_24h` | `float` | &#x2717; | &#x2713; | &#x2717; | percent (expresed as decimal); secondary sort criterion for tokens & pairs |
+| `price_usd_latest` | `float` | &#x2717; | &#x2713; | &#x2717; | in USD; not valuable for filtering / ranking - used for display only |
+| `pool_swap_fee` | `float` | &#x2717; | &#x2713; | &#x2717; | percent (expressed as decimal); only applies to Uniswap V3 (or similar) pairs<br>current possible values: `0.0005` (`0.05%`), `0.003` (`0.3%`), `0.01` (1%) |
 | `url_path` | `string` | &#x2717; | &#x2717; | &#x2717; | path of entity on tradingstrategy.ai (not including URL base) |
 
 ## File Format

--- a/schemas/trading-entities.json
+++ b/schemas/trading-entities.json
@@ -10,11 +10,12 @@
     { "name": "smart_contract_addresses", "type": "string[]" },
     { "name": "token_tickers", "type": "string[]", "optional": true },
     { "name": "token_names", "type": "string[]", "optional": true },
+    { "name": "quality_factors", "type": "string[]","optional": true, "index": false },
     { "name": "volume_24h", "type": "float", "optional": true },
     { "name": "liquidity", "type": "float", "optional": true },
     { "name": "price_change_24h", "type": "float", "optional": true },
     { "name": "price_usd_latest", "type": "float", "optional": true },
-    { "name": "icon_url", "type": "string", "optional": true, "index": false },
+    { "name": "pool_swap_fee", "type": "float", "optional": true },
     { "name": "url_path", "type": "string", "optional": true, "index": false }
   ]
 }


### PR DESCRIPTION
# Summary

This PR updates the `trading-entities` collection with additional fields to support Uniswap V3. See tradingstrategy-ai/oracle#157 for additional background.

## Details

### Add `quality_factors` field

See tradingstrategy-ai/oracle#156

@miohtama suggested adding a flag called `liquidity-consideration-not-applicable`. After further thought, I think it's preferable to use a string array field as this gives us more flexibility to introduce other quality factors in the future (without having to add a separate flag for each one).

For now, the only valid `quality_factors` value is `"liquidity"`. This value would be set on all trading pairs _except_ Uniswap V3 pairs. When search results are returned to `frontend`, if a search result record includes a value of `"liquidity"` in the `quality_factors`, the record will be displayed as "low quality" in the UI if the liquidity is below a threshold value (currently a local constant of `50,000` in `frontend`). Since Uniswap V3 pairs _won't_ include this value, these records will not be flagged as "low quality".

### Add `pool_swap_fee` field

See #10 

The original suggestion was to call this field `fee_parcent` or `fee_basis`. I think `pool_swap_fee` is more descriptive. I followed the convention of other percent fields in the search index (e.g., `price_change_24h`) – stored as a `float` and expressed as a decimal – so a fee of `0.05%` is stored as `0.0005`.

### Remove unused `icon_url` field

When the search index was first created, we envisioned including an icon URL for every trading entity. This data is not currently available from our backend, so it's best to drop this field for now. It's trivial to add it back in the future.
